### PR TITLE
Add a template for bug report

### DIFF
--- a/docs/bug_report_template.md
+++ b/docs/bug_report_template.md
@@ -1,0 +1,39 @@
+<!--
+   SUPPORT FORM: This is to help us in diagnosing the issues
+you come accross
+-->
+
+### Identification
+
+- Role:
+ + Were you BTC buyer or seller?
+ + Offer maker or taker?
+- Trade ID:
+- Maker fee transaction ID:
+- Taker fee transaction ID:
+- Deposit transaction ID:
+
+### Description
+
+<!-- brief description of the bug -->
+
+
+#### Bisq Version
+
+- What version of Bisq are you using?
+
+- Did you create this wallet on a Bisq version previous to the one you're using currently?
+
+#### Device or machine
+
+- Operating System:
+- Version:
+
+
+#### Additional info
+Please share:
+- a screenshot of the summary of your trade in OPEN TRADES if it hasn't been moved to FAILED TRADES.
+- a screenshot of the details of your trade in FAILED TRADES if it has been moved FAILED TRADES.
+- a screenshot of the details of your trade under OPEN TRADES.
+- a screenshot of the details of your trade under DISPUTES.
+- your bisq.log. It can be found on your Bisq directory: https://bisq.wiki/Data_directory. It's called "bisq.log" but the ".log" may be omitted if your settings aren't set to show the file extension. You may also have other logs like "bisq_1.log" . The maximum size is 10.5 MB and once it arrives at that size it creates a new log file. So please share all logs you have.


### PR DESCRIPTION
Created a template for support agents or mediators to present to
traders when requesting logs or more from them.