### PR TITLE
Add DAO reimbursement template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dao-reimbursement-template.md
+++ b/.github/ISSUE_TEMPLATE/dao-reimbursement-template.md
@@ -1,0 +1,47 @@
+---
+name: Dao reimbursement template
+about: Template for reimbursements
+title: Reimbursement for _trader's onion address_
+labels: ''
+assignees: ''
+
+---
+
+
+SCREENSHOT HERE
+
+>_The screenshot from the Bisq client must have the **Trade ID**, **Deposit**, **Maker** and **Taker** TXIDs visible. Of course some trades do not have all 3 types, that is ok. Make sure all private information is covered (like bank accounts, name, etc). **Do not upload images where sensitive private data is visible!**_
+
+
+Reimbursement for trade [TRADE ID]
+
+I am BTC [buyer/seller] as [maker/taker] for [ASSET].
+Trade amount and asset: [AMOUNT] BTC for [X ASSET]
+Deposit amount: [AMOUNT] BTC
+
+Maker:  ..........
+Taker: ...........
+Deposit: ..........
+Delayed payout: ..........
+BuyerMultiSigPubKeyHex: ..........
+SellerMultiSigPubKeyHex: ..........
+
+Reimbursement amount: [AMOUNT] BTC / [30 day BSQ average] BSQ = [TOTAL AMOUNT] BSQ
+Reason for reimbursement: [REASON]
+
+BTC address ownership proof:
+
+>_Repeat the above for each trade you need to be reimbursed_
+
+>_A reimbursement request has to contain textual representation of **Maker**, **Taker** and **Deposit** TXIDs (copy them from the client to the issue). **All TXIDs that are visible in the screenshot must be copied to the issue in text form! Please use exact form for Maker/Taker/Deposit - no abbreviations like M:, T: or adding extra characters like "Maker TX:", etc. Leave those fields as they are and replace the "........" with the appropreate txid**_
+
+Bisq version:
+
+>_Provide the Bisq client version to help developers identify the causing issue._
+
+Other notes:
+
+>_Issue [#197](https://github.com/bisq-network/support/issues/197) can be used as a good example of a correct reimbursement request._
+
+
+>_Ping @refund-agent2 and your mediator_


### PR DESCRIPTION
I created a template for when a trader needs to request
reimbursement for security deposits or trade amounts.
https://github.com/bisq-network/support/issues/822 for example.
This type of requests has different requirement and it makes sense
to separate it from the current Reimbursement request template.